### PR TITLE
[INFRA-490] Change to NYT runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,9 @@ on:
 
 jobs:
   actions-tagger:
-    runs-on: ubuntu-20.04
+    runs-on:
+      group: nyt-runners
+      labels: nyt-2-core
     steps:
       - uses: Actions-R-Us/actions-tagger@v2
         with:


### PR DESCRIPTION
Moving from using ubuntu-20.4 to nyt runners